### PR TITLE
Updated to retain existing expiry input name attributes if they already exist

### DIFF
--- a/src/js/card-js.js
+++ b/src/js/card-js.js
@@ -944,7 +944,7 @@ CardJs.prototype.initExpiryMonthInput = function() {
   if(this.expiryMonthInput[0]) {
     this.expiryMonthInput.detach();
   } else {
-    this.expiryMonthInput = $("<input class='expiry-month' />");
+    this.expiryMonthInput = $("<input class='expiry-month' name='expiry-month' />");
   }
 };
 
@@ -954,7 +954,7 @@ CardJs.prototype.initExpiryYearInput = function() {
   if(this.expiryYearInput[0]) {
     this.expiryYearInput.detach();
   } else {
-    this.expiryYearInput = $("<input class='expiry-year' />");
+    this.expiryYearInput = $("<input class='expiry-year' name='expiry-year' />");
   }
 };
 
@@ -1058,8 +1058,8 @@ CardJs.prototype.setupExpiryInput = function() {
   } else {
 
     expiryInput = $("<div></div>");
-    this.expiryMonthInput = $("<input type='hidden' name='expiry-month' />");
-    this.expiryYearInput = $("<input type='hidden' name='expiry-year' />");
+    this.expiryMonthInput.attr("type", "hidden");
+    this.expiryYearInput.attr("type", "hidden");
 
     if(this.stripe) {
       this.expiryMonthInput.attr("data-stripe", "exp-month");

--- a/src/js/card-js.js
+++ b/src/js/card-js.js
@@ -919,7 +919,7 @@ CardJs.prototype.initCardNumberInput = function() {
   this.cardNumberInput.keyup(function(e) {
     $this.refreshCreditCardTypeIcon();
   });
-  this.cardNumberInput.change(CardJs.handleCreditCardNumberChange);
+  this.cardNumberInput.on('change paste', CardJs.handleCreditCardNumberChange);
 };
 
 


### PR DESCRIPTION
As per Issue #13 I've updated the `initExpiry*Input` and `setupExpiryInput` functions responsible for the expiry input fields. The goal is to retain any existing "name" attribute when initializing the library. Currently the hidden fields are reinitialized with static values, hard coded when the DOM elements are created.

I've moved the static name attribute from being declared in the `setup` function to the `init` function. This is just in case an existing element cannot be not found. This ensures that a valid jQuery object of the correct input element should now exist for the setup function to act on. It simply changes the `type` attribute to `hidden`, rather than re-initializing an entirely new DOM element.